### PR TITLE
On throw exception in process getting from container optional dependency use default value only if container don't have dependency or thrown not `CircularReferenceException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.2 under development
 
-- no changes in this release.
+- Bug #32: On throw exception in process getting from container optional dependency use default value only if container
+  don't have dependency or thrown not `CircularReferenceException` (vjik) 
 
 ## 1.0.1 December 19, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 1.0.2 under development
 
-- Bug #32: On throw exception in process getting from container optional dependency use default value only if container
-  don't have dependency or thrown not `CircularReferenceException` (vjik) 
+- Bug #32: Throw exception instead of returning default value if optional dependency exists but there is an exception when getting it (vjik) 
 
 ## 1.0.1 December 19, 2021
 

--- a/src/Exception/CircularReferenceException.php
+++ b/src/Exception/CircularReferenceException.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Definitions\Exception;
 
 /**
- * CircularReferenceException is thrown when DI configuration
- * contains self-references of any level and thus could not
+ * `CircularReferenceException` is thrown when DI configuration contains self-references of any level and thus could not
  * be resolved.
  */
 final class CircularReferenceException extends NotInstantiableException

--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -8,7 +8,7 @@ use Exception;
 use Psr\Container\ContainerExceptionInterface;
 
 /**
- * InvalidConfigException is thrown when definition configuration is not valid.
+ * `InvalidConfigException` is thrown when definition configuration is not valid.
  */
 final class InvalidConfigException extends Exception implements ContainerExceptionInterface
 {

--- a/src/Exception/NotInstantiableClassException.php
+++ b/src/Exception/NotInstantiableClassException.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Definitions\Exception;
 use Exception;
 
 /**
- * NotInstantiableClassException is thrown when a class can not be instantiated for whatever reason.
+ * `NotInstantiableClassException` is thrown when a class can not be instantiated for whatever reason.
  */
 final class NotInstantiableClassException extends NotInstantiableException
 {

--- a/src/Exception/NotInstantiableException.php
+++ b/src/Exception/NotInstantiableException.php
@@ -8,8 +8,8 @@ use Exception;
 use Psr\Container\ContainerExceptionInterface;
 
 /**
- * NotInstantiableException represents an exception caused by incorrect dependency injection container
- * or factory configuration or usage.
+ * `NotInstantiableException` represents an exception caused by incorrect dependency injection container or factory
+ * configuration or usage.
  */
 class NotInstantiableException extends Exception implements ContainerExceptionInterface
 {

--- a/src/ParameterDefinition.php
+++ b/src/ParameterDefinition.php
@@ -10,8 +10,10 @@ use ReflectionParameter;
 use ReflectionUnionType;
 use Throwable;
 use Yiisoft\Definitions\Contract\DefinitionInterface;
+use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
+
 use function get_class;
 use function gettype;
 use function is_object;
@@ -83,7 +85,13 @@ final class ParameterDefinition implements DefinitionInterface
                 /** @var mixed */
                 $result = $container->get($typeName);
             } catch (Throwable $t) {
-                if ($this->parameter->isOptional()) {
+                if (
+                    $this->parameter->isOptional()
+                    && (
+                        $t instanceof CircularReferenceException
+                        || !$container->has($typeName)
+                    )
+                ) {
                     return $this->parameter->getDefaultValue();
                 }
                 throw $t;

--- a/tests/Support/CircularReferenceExceptionDependency.php
+++ b/tests/Support/CircularReferenceExceptionDependency.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Definitions\Tests\Support;
+
+use Yiisoft\Definitions\Exception\CircularReferenceException;
+
+final class CircularReferenceExceptionDependency
+{
+    public function __construct()
+    {
+        throw new CircularReferenceException('Broken.');
+    }
+}

--- a/tests/Support/RuntimeExceptionDependency.php
+++ b/tests/Support/RuntimeExceptionDependency.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Definitions\Tests\Support;
+
+use RuntimeException;
+
+final class RuntimeExceptionDependency
+{
+    public function __construct()
+    {
+        throw new RuntimeException('Broken.');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #32

And minor cleanup.

Tests pass also in di, factory, injector and app. In demo tests pass if increase `psr/container` to `1.1`.

❗DO NOT MERGE after review. If it is OK, then need make similar changes for union types.