### PR TITLE
Make `DefinitionValidator::validateArrayDefinition()` public and remove `ParameterDefinition::isBuiltin()` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.3 under development
 
-- no changes in this release.
+- New #37: Make method `DefinitionValidator::validateArrayDefinition()` public (vjik)
 
 ## 1.0.2 April 01, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Yii Definitions Change Log
 
-## 1.0.3 under development
+## 1.1.0 under development
 
 - New #37: Make method `DefinitionValidator::validateArrayDefinition()` public (vjik)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0 under development
 
 - New #37: Make method `DefinitionValidator::validateArrayDefinition()` public (vjik)
+- Chg #37: Remove method `ParameterDefinition::isBuiltin()` (vjik)
 
 ## 1.0.2 April 01, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Yii Definitions Change Log
 
-## 1.1.0 under development
+## 2.0.0 under development
 
 - New #37: Make method `DefinitionValidator::validateArrayDefinition()` public (vjik)
 - Chg #37: Remove method `ParameterDefinition::isBuiltin()` (vjik)

--- a/src/DefinitionStorage.php
+++ b/src/DefinitionStorage.php
@@ -147,7 +147,10 @@ final class DefinitionStorage
                 if ($type instanceof ReflectionUnionType) {
                     $isUnionTypeResolvable = false;
                     $unionTypes = [];
-                    /** @var ReflectionNamedType $unionType */
+                    /**
+                     * @psalm-suppress UnnecessaryVarAnnotation Annotation below is needed in PHP 7.4
+                     * @var ReflectionNamedType $unionType
+                     */
                     foreach ($type->getTypes() as $unionType) {
                         if (!$unionType->isBuiltin()) {
                             $typeName = $unionType->getName();

--- a/src/Helpers/DefinitionValidator.php
+++ b/src/Helpers/DefinitionValidator.php
@@ -55,9 +55,13 @@ final class DefinitionValidator
     }
 
     /**
-     * @throws InvalidConfigException
+     * Validates that array definition is valid. Throws exception otherwise.
+     *
+     * @param array $definition Array definition to validate.
+     *
+     * @throws InvalidConfigException If definition is not valid.
      */
-    private static function validateArrayDefinition(array $definition, ?string $id): void
+    public static function validateArrayDefinition(array $definition, ?string $id = null): void
     {
         foreach ($definition as $key => $value) {
             if (!is_string($key)) {

--- a/src/ParameterDefinition.php
+++ b/src/ParameterDefinition.php
@@ -169,6 +169,8 @@ final class ParameterDefinition implements DefinitionInterface
         $parameterType = $this->parameter->getType();
 
         /**
+         * @psalm-suppress UndefinedDocblockClass This annotation is needed in PHP 7.4
+         *
          * @var ReflectionNamedType[] $types
          */
         $types = $parameterType->getTypes();

--- a/src/ParameterDefinition.php
+++ b/src/ParameterDefinition.php
@@ -162,6 +162,8 @@ final class ParameterDefinition implements DefinitionInterface
     private function resolveUnionType(ContainerInterface $container)
     {
         /**
+         * @psalm-suppress UndefinedDocblockClass This annotation is needed in PHP 7.4
+         *
          * @var ReflectionUnionType $parameterType
          */
         $parameterType = $this->parameter->getType();

--- a/tests/Unit/ParameterDefinitionTest.php
+++ b/tests/Unit/ParameterDefinitionTest.php
@@ -234,34 +234,6 @@ final class ParameterDefinitionTest extends TestCase
         $definition->resolve($container);
     }
 
-    public function dataIsBuiltin(): array
-    {
-        return [
-            [
-                true,
-                $this->getFirstParameter(static fn (int $n) => 42),
-            ],
-            [
-                false,
-                $this->getFirstParameter(static fn (Car $car) => 42),
-            ],
-            [
-                false,
-                $this->getFirstParameter(static fn ($x) => 42),
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider dataIsBuiltin
-     */
-    public function testIsBuiltin(bool $expected, ReflectionParameter $parameter): void
-    {
-        $definition = new ParameterDefinition($parameter);
-
-        $this->assertSame($expected, $definition->isBuiltin());
-    }
-
     public function testOptionalBrokenDependency(): void
     {
         $container = new SimpleContainer(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | -

**Why remove `isBuiltin()` ?**

From PHP 8.0 method was removed from the `ReflectionType` and available in `ReflectionNamedType` only.
