### PR TITLE
Rename method `ArrayDefinition::setReferenceContainer()` to `withReferenceContainer()` and make him immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - New #37: Make method `DefinitionValidator::validateArrayDefinition()` public (vjik)
 - Chg #37: Remove method `ParameterDefinition::isBuiltin()` (vjik)
-- Chg #30: Rename method `ArrayDefinition::setReferenceContainer()` to `withReferenceContainer()` and make him
+- Chg #30: Rename method `ArrayDefinition::setReferenceContainer()` to `withReferenceContainer()` and make it
   immutable (vjik)
 
 ## 1.0.2 April 01, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - New #37: Make method `DefinitionValidator::validateArrayDefinition()` public (vjik)
 - Chg #37: Remove method `ParameterDefinition::isBuiltin()` (vjik)
+- Chg #30: Rename method `ArrayDefinition::setReferenceContainer()` to `withReferenceContainer()` and make him
+  immutable (vjik)
 
 ## 1.0.2 April 01, 2022
 

--- a/src/ArrayDefinition.php
+++ b/src/ArrayDefinition.php
@@ -59,9 +59,11 @@ final class ArrayDefinition implements DefinitionInterface
     /**
      * @param ContainerInterface|null $referenceContainer Container to resolve references with.
      */
-    public function setReferenceContainer(?ContainerInterface $referenceContainer): void
+    public function withReferenceContainer(?ContainerInterface $referenceContainer): self
     {
-        $this->referenceContainer = $referenceContainer;
+        $new = clone $this;
+        $new->referenceContainer = $referenceContainer;
+        return $new;
     }
 
     /**

--- a/tests/Unit/ArrayDefinitionTest.php
+++ b/tests/Unit/ArrayDefinitionTest.php
@@ -314,11 +314,12 @@ final class ArrayDefinitionTest extends TestCase
             'class' => Car::class,
             'setColor()' => [Reference::to(ColorInterface::class)],
         ]);
-        $definition->setReferenceContainer($referenceContainer);
+        $newDefinition = $definition->withReferenceContainer($referenceContainer);
 
         /** @var Car $object */
-        $object = $definition->resolve($container);
+        $object = $newDefinition->resolve($container);
 
+        $this->assertNotSame($definition, $newDefinition);
         $this->assertInstanceOf(Car::class, $object);
         $this->assertInstanceOf(EngineMarkOne::class, $object->getEngine());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #30 

## Add support for `yiisoft/definitions` version `^2.0`

### Released packages

- https://github.com/yiisoft/di/pull/303
- https://github.com/yiisoft/factory/pull/159
- https://github.com/yiisoft/widget/pull/55
- https://github.com/yiisoft/yii-runner/pull/15
- https://github.com/yiisoft/yii-runner-console/pull/19
- https://github.com/yiisoft/yii-runner-http/pull/23
- https://github.com/yiisoft/yii-runner-roadrunner/pull/27
- https://github.com/yiisoft/validator-rule-handler-container/pull/3

### Non-released packages

- https://github.com/yiisoft/yii-queue/pull/124
- https://github.com/yiisoft/rbac-rules-container/pull/8

## Increase `yiisoft/definitions` version to `^2.0`

Merge after new release of already released packages above.

- https://github.com/yiisoft/app/pull/241
- https://github.com/yiisoft/app-api/pull/131
- https://github.com/yiisoft/demo/pull/459
- https://github.com/yiisoft/demo-api/pull/91