### PR TITLE
Definition validator returns false positive result on empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #44: In methods of array definitions add autowiring and improve variadic arguments support (@vjik)
 - Enh #41: Raise minimum PHP version to 8.0 and refactor code (@xepozz, @vjik)
+- Bug #48: Definition validator returns false positive result on empty string (@vjik) 
 
 ## 2.1.0 October 25, 2022
 

--- a/src/Helpers/DefinitionValidator.php
+++ b/src/Helpers/DefinitionValidator.php
@@ -39,7 +39,7 @@ final class DefinitionValidator
         }
 
         // Callable definition
-        if (is_callable($definition, true)) {
+        if (is_callable($definition, true) && $definition !== '') {
             return;
         }
 
@@ -49,7 +49,10 @@ final class DefinitionValidator
             return;
         }
 
-        throw new InvalidConfigException('Invalid definition: ' . var_export($definition, true));
+        throw new InvalidConfigException(
+            'Invalid definition: '
+            . ($definition === '' ? 'empty string.' : var_export($definition, true))
+        );
     }
 
     /**

--- a/src/Helpers/DefinitionValidator.php
+++ b/src/Helpers/DefinitionValidator.php
@@ -39,7 +39,7 @@ final class DefinitionValidator
         }
 
         // Callable definition
-        if (is_callable($definition, true) && $definition !== '') {
+        if ($definition !== '' && is_callable($definition, true)) {
             return;
         }
 

--- a/tests/Unit/Helpers/DefinitionValidatorTest.php
+++ b/tests/Unit/Helpers/DefinitionValidatorTest.php
@@ -56,6 +56,13 @@ final class DefinitionValidatorTest extends TestCase
         DefinitionValidator::validate([]);
     }
 
+    public function testEmptyString(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Invalid definition: empty string.');
+        DefinitionValidator::validate('');
+    }
+
     public function testInvalidConstructor(): void
     {
         $this->expectException(InvalidConfigException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
