### PR TITLE
Change result format of `DefinitionStorage::getBuildStack()` method to definition IDs array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #46: In definition validator add a check of method name in array definitions (@vjik) 
 - Enh #44: In methods of array definitions add autowiring and improve variadic arguments support (@vjik)
 - Enh #41: Raise minimum PHP version to 8.0 and refactor code (@xepozz, @vjik)
+- Chg #49: Change result format of `DefinitionStorage::getBuildStack()` method to definition IDs array (@vjik) 
 
 ## 2.1.0 October 25, 2022
 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ if (!$storage->has(MyInterface::class)) {
 }
 ```
 
-In the above `$buildStack` will contain a stack with definition IDs as keys and 1 as values in the order the latest
-dependency obtained would be built.
+In the above `$buildStack` will contain a stack with definition IDs in the order the latest dependency obtained would be
+built.
 
 By default, if a class is checked in `has()` and it is not explicitly defined, the storage tries to autoload it first
 before failing. The storage may also work in a strict mode when everything in it should be defined explicitly:

--- a/src/DefinitionStorage.php
+++ b/src/DefinitionStorage.php
@@ -53,20 +53,21 @@ final class DefinitionStorage
     }
 
     /**
-     * Returns a stack with definition IDs as keys and 1 as values in the order the latest dependency obtained would
-     * be built.
+     * Returns a stack with definition IDs in the order the latest dependency obtained would be built.
      *
-     * @return array Build stack.
+     * @return string[] Build stack.
      */
     public function getBuildStack(): array
     {
-        return $this->buildStack;
+        return array_keys($this->buildStack);
     }
 
     /**
      * Get a definition with a given ID.
      *
      * @return mixed|object Definition with a given ID.
+     *
+     * @throws CircularReferenceException
      */
     public function get(string $id): mixed
     {

--- a/src/DefinitionStorage.php
+++ b/src/DefinitionStorage.php
@@ -17,6 +17,9 @@ use Yiisoft\Definitions\Helpers\DefinitionExtractor;
  */
 final class DefinitionStorage
 {
+    /**
+     * @var array<string,1>
+     */
     private array $buildStack = [];
 
     private ?ContainerInterface $delegateContainer = null;
@@ -89,6 +92,8 @@ final class DefinitionStorage
     }
 
     /**
+     * @param array<string,1> $building
+     *
      * @throws CircularReferenceException
      */
     private function isResolvable(string $id, array $building): bool

--- a/tests/Unit/DefinitionStorageTest.php
+++ b/tests/Unit/DefinitionStorageTest.php
@@ -71,7 +71,7 @@ final class DefinitionStorageTest extends TestCase
     {
         $storage = new DefinitionStorage([]);
         $this->assertFalse($storage->has(NonExisitng::class));
-        $this->assertSame([NonExisitng::class => 1], $storage->getBuildStack());
+        $this->assertSame([NonExisitng::class], $storage->getBuildStack());
     }
 
     public function testServiceWithNonExistingDependency(): void
@@ -80,8 +80,8 @@ final class DefinitionStorageTest extends TestCase
         $this->assertFalse($storage->has(ServiceWithNonExistingDependency::class));
         $this->assertSame(
             [
-                ServiceWithNonExistingDependency::class => 1,
-                \NonExisting::class => 1,
+                ServiceWithNonExistingDependency::class,
+                \NonExisting::class,
             ],
             $storage->getBuildStack()
         );
@@ -93,9 +93,9 @@ final class DefinitionStorageTest extends TestCase
         $this->assertFalse($storage->has(ServiceWithNonExistingSubDependency::class));
         $this->assertSame(
             [
-                ServiceWithNonExistingSubDependency::class => 1,
-                ServiceWithNonExistingDependency::class => 1,
-                \NonExisting::class => 1,
+                ServiceWithNonExistingSubDependency::class,
+                ServiceWithNonExistingDependency::class ,
+                \NonExisting::class,
             ],
             $storage->getBuildStack()
         );
@@ -105,7 +105,7 @@ final class DefinitionStorageTest extends TestCase
     {
         $storage = new DefinitionStorage([]);
         $this->assertFalse($storage->has(ServiceWithPrivateConstructor::class));
-        $this->assertSame([ServiceWithPrivateConstructor::class => 1], $storage->getBuildStack());
+        $this->assertSame([ServiceWithPrivateConstructor::class], $storage->getBuildStack());
     }
 
     public function testServiceWithPrivateConstructorSubDependency(): void
@@ -114,8 +114,8 @@ final class DefinitionStorageTest extends TestCase
         $this->assertFalse($storage->has(ServiceWithPrivateConstructorSubDependency::class));
         $this->assertSame(
             [
-                ServiceWithPrivateConstructorSubDependency::class => 1,
-                ServiceWithPrivateConstructor::class => 1,
+                ServiceWithPrivateConstructorSubDependency::class,
+                ServiceWithPrivateConstructor::class,
             ],
             $storage->getBuildStack()
         );
@@ -125,7 +125,7 @@ final class DefinitionStorageTest extends TestCase
     {
         $storage = new DefinitionStorage([]);
         $this->assertFalse($storage->has(ServiceWithBuiltinTypeWithoutDefault::class));
-        $this->assertSame([ServiceWithBuiltinTypeWithoutDefault::class => 1], $storage->getBuildStack());
+        $this->assertSame([ServiceWithBuiltinTypeWithoutDefault::class], $storage->getBuildStack());
     }
 
     public function testEmptyDelegateContainer(): void
@@ -134,7 +134,7 @@ final class DefinitionStorageTest extends TestCase
         $storage = new DefinitionStorage([]);
         $storage->setDelegateContainer($container);
         $this->assertFalse($storage->has(\NonExisitng::class));
-        $this->assertSame([\NonExisitng::class => 1], $storage->getBuildStack());
+        $this->assertSame([\NonExisitng::class], $storage->getBuildStack());
     }
 
     public function testServiceWithNonExistingUnionTypes(): void
@@ -147,10 +147,10 @@ final class DefinitionStorageTest extends TestCase
         $this->assertFalse($storage->has(ServiceWithNonResolvableUnionTypes::class));
         $this->assertSame(
             [
-                ServiceWithNonResolvableUnionTypes::class => 1,
-                ServiceWithNonExistingDependency::class => 1,
-                \NonExisting::class => 1,
-                ServiceWithPrivateConstructor::class => 1,
+                ServiceWithNonResolvableUnionTypes::class,
+                ServiceWithNonExistingDependency::class,
+                \NonExisting::class,
+                ServiceWithPrivateConstructor::class,
             ],
             $storage->getBuildStack()
         );
@@ -207,6 +207,19 @@ final class DefinitionStorageTest extends TestCase
             'Circular reference to "' . SelfDependency::class . '" detected while building: ' . SelfDependency::class
         );
         $storage->get(SelfDependency::class);
+    }
+
+    public function testBuildStackOnThrowException(): void
+    {
+        $storage = new DefinitionStorage();
+
+        try {
+            $storage->get(Chicken::class);
+        } catch (CircularReferenceException) {
+            $stack = $storage->getBuildStack();
+        }
+
+        $this->assertSame([Chicken::class, Egg::class], $stack);
     }
 
     public function testWithoutDependencies(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
