### PR TITLE
Fixed error on use in array definition methods that should be work via magic `__call()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1 under development
 
-- no changes in this release.
+- Bug #53: Fixed error on use in array definition methods that should be work via magic `__call()` method (@vjik)
 
 ## 3.0.0 November 04, 2022
 

--- a/src/ArrayDefinition.php
+++ b/src/ArrayDefinition.php
@@ -150,11 +150,15 @@ final class ArrayDefinition implements DefinitionInterface
             [$type, $name, $value] = $item;
             if ($type === self::TYPE_METHOD) {
                 /** @var array $value */
-                $resolvedMethodArguments = $this->resolveFunctionArguments(
-                    $container,
-                    DefinitionExtractor::fromFunction(new ReflectionMethod($object, $name)),
-                    $value,
-                );
+                if (method_exists($object, $name)) {
+                    $resolvedMethodArguments = $this->resolveFunctionArguments(
+                        $container,
+                        DefinitionExtractor::fromFunction(new ReflectionMethod($object, $name)),
+                        $value,
+                    );
+                } else {
+                    $resolvedMethodArguments = $value;
+                }
                 /** @var mixed $setter */
                 $setter = call_user_func_array([$object, $name], $resolvedMethodArguments);
                 if ($setter instanceof $object) {

--- a/tests/Support/Recorder.php
+++ b/tests/Support/Recorder.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Definitions\Tests\Support;
+
+final class Recorder
+{
+    private array $record = [];
+
+    public function __call($name, $arguments)
+    {
+        $arguments = array_map(
+            static fn ($argument) => get_debug_type($argument),
+            $arguments,
+        );
+
+        $this->record[] = 'Call ' . $name . '(' . implode(', ', $arguments) . ')';
+    }
+
+    public function __isset($name)
+    {
+        return true;
+    }
+
+    public function __set($name, $value)
+    {
+        $this->record[] = "Set $$name to " . get_debug_type($value);
+    }
+
+    public function __get($name)
+    {
+        return null;
+    }
+
+    public function getEvents(): array
+    {
+        return $this->record;
+    }
+}

--- a/tests/Unit/ArrayDefinitionTest.php
+++ b/tests/Unit/ArrayDefinitionTest.php
@@ -518,7 +518,7 @@ final class ArrayDefinitionTest extends TestCase
                 'Call first()',
                 'Set $second to null',
                 'Call third(string, bool)',
-                'Set $fourth to string'
+                'Set $fourth to string',
             ],
             $object->getEvents()
         );

--- a/tests/Unit/ArrayDefinitionTest.php
+++ b/tests/Unit/ArrayDefinitionTest.php
@@ -17,6 +17,7 @@ use Yiisoft\Definitions\Tests\Support\EngineMarkOne;
 use Yiisoft\Definitions\Tests\Support\EngineMarkTwo;
 use Yiisoft\Definitions\Tests\Support\Mouse;
 use Yiisoft\Definitions\Tests\Support\Phone;
+use Yiisoft\Definitions\Tests\Support\Recorder;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class ArrayDefinitionTest extends TestCase
@@ -498,5 +499,28 @@ final class ArrayDefinitionTest extends TestCase
         $this->assertNotSame($definition, $newDefinition);
         $this->assertInstanceOf(Car::class, $object);
         $this->assertInstanceOf(EngineMarkOne::class, $object->getEngine());
+    }
+
+    public function testMagicMethods(): void
+    {
+        $definiton = ArrayDefinition::fromConfig([
+            'class' => Recorder::class,
+            'first()' => [],
+            '$second' => null,
+            'third()' => ['hello', true],
+            '$fourth' => 'hello',
+        ]);
+
+        $object = $definiton->resolve(new SimpleContainer());
+
+        $this->assertSame(
+            [
+                'Call first()',
+                'Set $second to null',
+                'Call third(string, bool)',
+                'Set $fourth to string'
+            ],
+            $object->getEvents()
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
