### PR TITLE
Remove extending InvalidConfigException with ContainerExceptionInterface

### DIFF
--- a/src/Exception/InvalidConfigException.php
+++ b/src/Exception/InvalidConfigException.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Yiisoft\Definitions\Exception;
 
 use Exception;
-use Psr\Container\ContainerExceptionInterface;
 
 /**
  * `InvalidConfigException` is thrown when definition configuration is not valid.
  */
-final class InvalidConfigException extends Exception implements ContainerExceptionInterface
+final class InvalidConfigException extends Exception
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️

It's wrong behaviour to extend `InvalidConfigException` with `ContainerExceptionInterface`.
A config error is not container error by meaning.