### PR TITLE
Add ability to use any allowed definitions in `DynamicReferencesArray::from()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Yii Definitions Change Log
 
-## 3.1.1 under development
+## 3.2.0 under development
 
-- no changes in this release.
+- Enh #68: Add ability to use any allowed definitions in `DynamicReferencesArray::from()` (@vjik) 
 
 ## 3.1.0 February 04, 2023
 

--- a/src/DynamicReferencesArray.php
+++ b/src/DynamicReferencesArray.php
@@ -22,7 +22,7 @@ final class DynamicReferencesArray
      * it is done as:
      *
      * ```php
-     * //web.php
+     * // di-web.php
      *
      * ContentNegotiator::class => [
      *     '__construct()' => [
@@ -39,7 +39,7 @@ final class DynamicReferencesArray
      * `DynamicReference::to()` for each formatter:
      *
      * ```php
-     * //params.php
+     * // params.php
      * return [
      *      'yiisoft/data-response' => [
      *          'contentFormatters' => [
@@ -54,7 +54,7 @@ final class DynamicReferencesArray
      * Then we can use it like the following:
      *
      * ```php
-     * //web.php
+     * // di-web.php
      *
      * ContentNegotiator::class => [
      *     '__construct()' => [
@@ -63,22 +63,18 @@ final class DynamicReferencesArray
      * ],
      * ```
      *
-     * @param string[] $ids Name-reference pairs.
+     * @param array $ids Name-reference pairs.
      *
      * @throws InvalidConfigException
      *
      * @return DynamicReference[]
-     * @psalm-suppress DocblockTypeContradiction
      */
-    public static function from(array $ids): array
+    public static function from(array $definitions): array
     {
         $references = [];
 
-        foreach ($ids as $key => $id) {
-            if (!is_string($id)) {
-                throw new InvalidConfigException('Values of an array must be string alias or class name.');
-            }
-            $references[$key] = DynamicReference::to($id);
+        foreach ($definitions as $key => $definition) {
+            $references[$key] = DynamicReference::to($definition);
         }
 
         return $references;

--- a/src/DynamicReferencesArray.php
+++ b/src/DynamicReferencesArray.php
@@ -6,8 +6,6 @@ namespace Yiisoft\Definitions;
 
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 
-use function is_string;
-
 /**
  * Allows creating an array of dynamic references from key-reference pairs.
  *
@@ -58,12 +56,13 @@ final class DynamicReferencesArray
      *
      * ContentNegotiator::class => [
      *     '__construct()' => [
-     *         'contentFormatters' => DynamicReferencesArray::from($params['yiisoft/data-response']['contentFormatters']),
+     *         'contentFormatters' =>
+     * DynamicReferencesArray::from($params['yiisoft/data-response']['contentFormatters']),
      *     ],
      * ],
      * ```
      *
-     * @param array $ids Name-reference pairs.
+     * @param array $definitions Name-reference pairs.
      *
      * @throws InvalidConfigException
      *
@@ -73,6 +72,7 @@ final class DynamicReferencesArray
     {
         $references = [];
 
+        /** @var mixed $definition */
         foreach ($definitions as $key => $definition) {
             $references[$key] = DynamicReference::to($definition);
         }

--- a/tests/Unit/ReferencesArrayTest.php
+++ b/tests/Unit/ReferencesArrayTest.php
@@ -34,20 +34,16 @@ final class ReferencesArrayTest extends TestCase
 
     public function testDynamicReferencesArray(): void
     {
-        $ids = ['key1' => 'first', 'key2' => 'second'];
+        $definitions = [
+            'key1' => 'first',
+            'key2' => 'second',
+            static fn () => 'thrid',
+        ];
 
-        $references = DynamicReferencesArray::from($ids);
+        $references = DynamicReferencesArray::from($definitions);
 
         $this->assertInstanceOf(DynamicReference::class, $references['key1']);
         $this->assertInstanceOf(DynamicReference::class, $references['key2']);
-    }
-
-    public function testDynamicReferencesArrayFail(): void
-    {
-        $ids = ['first', 22];
-
-        $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionMessage('Values of an array must be string alias or class name.');
-        DynamicReferencesArray::from($ids);
+        $this->assertInstanceOf(DynamicReference::class, $references[0]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->
