### PR TITLE
Fix resolving `ParameterDefinition` for optional parameters with union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.1 under development
 
-- no changes in this release.
+- Bug #100: Fix resolving `ParameterDefinition` for optional parameters with union types (@vjik)
 
 ## 3.3.0 March 16, 2024
 

--- a/src/ParameterDefinition.php
+++ b/src/ParameterDefinition.php
@@ -192,7 +192,7 @@ final class ParameterDefinition implements DefinitionInterface
         }
 
         if ($this->parameter->isOptional()) {
-            return null;
+            return $this->parameter->getDefaultValue();
         }
 
         if (!isset($error)) {

--- a/tests/Support/UnionOptionalDependency.php
+++ b/tests/Support/UnionOptionalDependency.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Definitions\Tests\Support;
 final class UnionOptionalDependency
 {
     public function __construct(
-        private $value = null
+        private string|ColorInterface $value = 'test'
     ) {
     }
 

--- a/tests/Unit/ParameterDefinitionTest.php
+++ b/tests/Unit/ParameterDefinitionTest.php
@@ -16,6 +16,7 @@ use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
 use Yiisoft\Definitions\ParameterDefinition;
 use Yiisoft\Definitions\Tests\Support\CircularReferenceExceptionDependency;
+use Yiisoft\Definitions\Tests\Support\ColorInterface;
 use Yiisoft\Definitions\Tests\Support\GearBox;
 use Yiisoft\Definitions\Tests\Support\RuntimeExceptionDependency;
 use Yiisoft\Definitions\Tests\Support\Car;
@@ -334,11 +335,21 @@ final class ParameterDefinitionTest extends TestCase
     public function testResolveOptionalUnionType(): void
     {
         $definition = new ParameterDefinition(
+            $this->getFirstParameter(static fn (string|ColorInterface $value = 'test') => true)
+        );
+        $container = new SimpleContainer();
+
+        $this->assertSame('test', $definition->resolve($container));
+    }
+
+    public function testResolveOptionalPromotedPropertyUnionType(): void
+    {
+        $definition = new ParameterDefinition(
             $this->getFirstConstructorParameter(UnionOptionalDependency::class)
         );
         $container = new SimpleContainer();
 
-        $this->assertNull($definition->resolve($container));
+        $this->assertSame('test', $definition->resolve($container));
     }
 
     public function testResolveUnionBuiltin(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Tests in Yii DI and Yii Factory with these changes are passed.